### PR TITLE
Persist ad ledger across code upgrades

### DIFF
--- a/src/ads_ledger/main.mo
+++ b/src/ads_ledger/main.mo
@@ -116,10 +116,20 @@ actor AdsLedger {
     /// Next available `Ad` id
     ///
     /// TODO: Could this be subject to race conditions? Docs unclear on when race conditions are possible
-    var nextID : AdID = 0;
+    stable var nextID : AdID = 0;
 
-    /// Ad repository
-    var ads = TrieMap.TrieMap<AdID, Ad>(equalID, hashID);    
+    /// Ad repository backup used during canister code upgrades
+    stable var adsBackup : [(AdID, Ad)] = [];
+    /// Ad repository used during runtime
+    var ads = TrieMap.fromEntries(adsBackup.vals(), equalID, hashID);
+
+    system func preupgrade() {
+        adsBackup := Iter.toArray(ads.entries());
+    };
+
+    system func postupgrade() {
+        adsBackup := [];
+    };
 
     /**
      * "API" I guess


### PR DESCRIPTION
By default, canisters lose all their state when their code is upgraded. Variables declared as `stable` persist across upgrades.

However, the TrieMap used to store ads cannot be made stable. To get around this, system functions are used to convert the map to a stable array before the upgrade and then read into the map after the upgrade.

Closes #6