### PR TITLE
Limit www canister to just ads_ledger canister

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This code makes up the backend service for Ethical Targeting, running on the [DF
 So far this is made up of three canisters:
 
 * `ads_ledger`: Place where ads are stored and retrieved from
-* `www`: Web interface to manage ads (currently unmodified [Candid UI](https://github.com/dfinity/candid/tree/master/tools/ui))
+* `www`: Web interface to manage ads (slightly modified version of [in-development Candid UI](https://github.com/dfinity/candid/tree/c54bb6c158/tools/ui))
 
 ## Build
 
@@ -28,6 +28,14 @@ Then you can clone the repository and build:
 git clone https://github.com/jkmartindale/ethical_targeting-backend.git
 cd ethical_targeting-backend
 npm install
-dfx start --background
-dfx deploy
+# Required to generate canister_ids.json
+dfx canister --network=ic create --all
+# All that's necessary after the first run
+dfx deploy --network=ic
 ```
+
+The console output of `dfx` should list canister IDs for `ads_ledger` and `www`, which you can also find in `canister_ids.json`.
+
+Access the all ads JSON endpoint at `<ads_ledger-canister_id>.ic0.app` and the ads manager at `<www-canister_id>.ic0.app`.
+
+Currently the ad manager can only make calls against a canister on the `ic` network. Since it is basically equivalent to Candid UI, you can instead visit `http://127.0.0.1:8000/candid?canisterId=<www-canister_id>` for a very similar experience.

--- a/src/www/candid.css
+++ b/src/www/candid.css
@@ -34,22 +34,12 @@
 #container {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - var(--header-height));
+  height: 100vh;
 }
 
 #main-content {
   flex: 1;
   overflow: auto;
-}
-
-#header {
-  height: var(--header-height);
-  width: 100%;
-  text-align: center;
-  font-size: var(--font-md);
-  line-height: var(--header-height);
-  color: var(--darkest);
-  border-bottom: 1px solid var(--dark);
 }
 
 #title-card {
@@ -332,11 +322,6 @@ textarea:focus {
     --console-width: clamp(28rem, 30vw, 40rem);
   }
 
-  #header {
-    text-align: left;
-    padding-left: 3rem;
-  }
-
   #container {
     flex-direction: row;
     overflow: auto;
@@ -372,13 +357,13 @@ textarea:focus {
     display: flex;
     flex-direction: row-reverse;
     width: var(--header-height);
-    height: calc(100vh - var(--header-height));
+    height: 100vh;
     padding: 0;
     transition: width 0.2s ease-in-out;
   }
   #console.open {
     width: calc(var(--header-height) + var(--console-width));
-    height: calc(100vh - var(--header-height));
+    height: 100vh;
   }
 
   #console-bar {
@@ -427,6 +412,6 @@ textarea:focus {
 
   #output-list,
   #methods-list {
-    height: calc(100vh - (var(--header-height) * 2));
+    height: 100vh;
   }
 }

--- a/src/www/candid.html
+++ b/src/www/candid.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8" />
-  <title>DFINITY Canister Candid UI</title>
+  <title>Ethical Targeting Ad Manager</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-reboot@4.5.4/reboot.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" />
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet" />
@@ -17,15 +17,14 @@
 
 <body>
   <div id="progress">
-    <progress class="ic_progress" id="ic-progress">Loading Candid UI...</progress>
+    <progress class="ic_progress" id="ic-progress">Loading ad manager...</progress>
   </div>
   <app id="app" style="display: none">
-    <div id="header">Canister ID:&nbsp;<span id="canisterId"></span></div>
     <div id="container">
       <div id="main-content">
         <div id="title-card">
-          <h1 id="title">Candid UI</h1>
-          Browse and test your API with our visual web interface.
+          <h1 id="title">Ethical Targeting Ad Manager</h1>
+          Debug console
         </div>
         <ul id="methods"></ul>
       </div>

--- a/src/www/candid.ts
+++ b/src/www/candid.ts
@@ -65,7 +65,6 @@ async function getRemoteDidJs(canisterId: Principal): Promise<undefined | string
 }
 
 export function render(id: Principal, canister: CanisterActor) {
-    document.getElementById('canisterId')!.innerText = `${id}`;
     const sortedMethods = Actor.interfaceOf(canister)._fields.sort(([a], [b]) => (a > b ? 1 : -1));
     for (const [name, func] of sortedMethods) {
         renderMethod(canister, name, func);

--- a/src/www/index.ts
+++ b/src/www/index.ts
@@ -1,14 +1,12 @@
 import { fetchActor, render } from './candid';
 import { Principal } from '@dfinity/agent';
+import canisters from '../../canister_ids.json';
 
 async function main() {
-    const params = new URLSearchParams(window.location.search);
-    const cid = params.get('id');
-    if (!cid) {
-        throw new Error('Provide parameter id in the URL as the target canister id');
+    if (!canisters.ads_ledger || !canisters.ads_ledger.ic) {
+        throw new Error('Ensure canister_ids.json specifies an `ads_ledger` canister ID on the ic network');
     } else {
-        document.title = `Canister ${cid}`;
-        const canisterId = Principal.fromText(cid);
+        const canisterId = Principal.fromText(canisters.ads_ledger.ic);
         const actor = await fetchActor(canisterId);
         render(canisterId, actor);
         const app = document.getElementById('app');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,11 @@
     "lib": ["dom", "es2017"],
     "module": "commonjs",
     "outDir": "ts-out/",
+    "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
     "target": "ES2017"
   },
-  "include": ["src/**/*.ts", "src/**/*.css"],
+  "include": ["src/**/*.ts", "src/**/*.css", "canister_ids.json"],
   "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
Candid UI by default connects to any canister specified by the `id` GET variable. Since this instance of the canister is meant to be single-purpose, it would make sense to access that canister by default and remove the option to switch.

Along with that, some changes to replace "Candid UI" with "Ethical Targeting", just to emphasize what exactly is being accessed here.