### PR TITLE
Split Ad, Target, and JSON modules from main

### DIFF
--- a/src/ads_ledger/Ad.mo
+++ b/src/ads_ledger/Ad.mo
@@ -1,0 +1,35 @@
+import Target "Target";
+import Time "mo:base/Time";
+
+/// Types and associated functions for ads in the ledger
+module {
+    /// Unique identifier for an ad
+    public type ID = Nat;
+
+    /// Image that serves as ad content
+    public type Image = {
+        /// Publicly accessible URL of image
+        url : Text;
+        /// Height of image in pixels
+        height : Nat16;
+        /// Width of image in pixels
+        width : Nat16;
+    };
+
+    /// Ad campaign containing `image` and `link` to be shown to users matching `profile` between `start` and `end`
+    public type Ad = {
+        /// User with control over this ad
+        owner : Text;
+        /// Image that serves as ad content
+        image : Image;
+        /// URL the user should visit after clicking on the ad
+        link : Text;
+        /// Profile attributes this ad is relevant to, or null for no targeting
+        profile : ?Target.Target;
+        /// Time this campaign starts
+        start : ?Time.Time;
+        /// Time this campaign ends
+        end : ?Time.Time;
+    };
+
+}

--- a/src/ads_ledger/JSON.mo
+++ b/src/ads_ledger/JSON.mo
@@ -1,0 +1,167 @@
+import Int "mo:base/Int";
+import Iter "mo:base/Iter";
+import Nat "mo:base/Nat";
+import Nat16 "mo:base/Nat16";
+import Text "mo:base/Text";
+import Time "mo:base/Time";
+
+import Ad "Ad";
+import Target "Target";
+
+/// Functions to convert types to strings of JSON
+module {
+    /// Wrap text in double quotes
+    func quote(text : Text) : Text {
+        "\"" # text # "\""
+    };
+
+    /**
+     * Base JSON types
+     */
+
+    /// Convert an iterator of JSON objects to a JSON array
+    public func array(jsonObj : Iter.Iter<Text>) : Text {
+        "[" # 
+            Text.join(",", jsonObj) #
+        "]"
+    };
+
+    /// Convert key-value tuples to a JSON object
+    ///
+    /// The key must be unquoted (quotes will be escaped) and the value must be safe, valid JSON as-is. This is because keys can only be strings but values can be any type.
+    public func obj(properties : [(Text, Text)]) : Text {
+        "{" #
+            Text.join(",",
+                Iter.map(Iter.fromArray(properties), func ((key : Text, value : Text)) : Text {
+                    text(key) # ":" # value
+                })
+            ) #
+        "}"
+    };
+
+    /// Convert a nullable object to JSON
+    ///
+    /// Requires passing a function to convert the type to a string of JSON. Passing functions in this module should be sufficient, e.g. JSON.text or JSON.gender
+    public func nullable<T>(jsonify : T -> Text, obj : ?T) : Text {
+        switch obj {
+            case null "null";
+            case (?obj) jsonify(obj);
+        }
+    };
+
+    /// Escape a text value and wrap it in double quotes
+    public func text(text : Text) : Text {
+        quote(
+            Text.replace(
+            Text.replace(
+            Text.replace(
+            Text.replace(
+            Text.replace(text,
+            #char '\"', "\\\""),
+            #char '\\' , "\\\\"),
+            #char '\n' , "\\n"),
+            #char '\r' , "\\r"),
+            #char '\t' , "\\t")
+        )
+    };
+
+    /**
+     * Ad ledger types
+     */
+
+    /// Convert an age variant to JSON
+    public func age(age : Target.Age) : Text {
+        quote(switch age {
+            case (#age0_12) "0-12";
+            case (#age13_17) "13-17";
+            case (#age18_24) "18-24";
+            case (#age25_34) "25-34";
+            case (#age35_44) "35-44";
+            case (#age45_54) "45-54";
+            case (#age55_64) "55-64";
+            case (#age65_74) "65-74";
+            case (#age75_) "75+";
+        })
+    };
+
+    /// Convert a dislike to JSON
+    public let dislike = text;
+
+    /// Convert a gender identity variant to JSON
+    public func gender(gender : Target.Gender) : Text {
+        quote(switch gender {
+            case (#masculine) "masculine";
+            case (#non_binary) "non_binary";
+            case (#feminine) "feminine";
+        })
+    };
+
+    /// Convert an ad image to JSON
+    public func image(image : Ad.Image) : Text {
+        obj([
+            ("url", quote(image.url)),
+            ("height", Nat16.toText(image.height)),
+            ("width", Nat16.toText(image.width)),
+        ])
+    };
+
+    /// Convert an industry to JSON
+    public let industry = text;
+
+    /// Convert an interest to JSON
+    public let interest = text;
+
+    /// Convert match rules to JSON
+    ///
+    /// Requires passing a function to convert the type to a JSON string. Passing functions in this module should be sufficient, e.g. JSON.text or JSON.gender
+    public func matchRules<T>(rules : ?Target.MatchRules<T>, jsonify : T -> Text) : Text {
+        // I would use nullable() here if Motoko supported currying
+        switch rules {
+            case null
+                "null";
+            case (?rules)
+                obj([
+                    ("all", array(Iter.map(Iter.fromArray(rules.all), jsonify))),
+                    ("some", array(Iter.map(Iter.fromArray(rules.some), jsonify))),
+                    ("none", array(Iter.map(Iter.fromArray(rules.none), jsonify))),
+                ])
+        }
+    };
+
+    /// Convert an occupation to JSON
+    public let occupation = text;
+
+    /// Convert an ad target to JSON
+    public func target(target : Target.Target) : Text {
+        obj([
+            ("age", matchRules(target.age, age)),
+            ("gender", matchRules(target.gender, gender)),
+            ("occupation", matchRules(target.occupation, occupation)),
+            ("industry", matchRules(target.industry, industry)),
+            ("interests", matchRules(target.interests, interest)),
+            ("dislikes", matchRules(target.dislikes, dislike)),
+        ])
+    };
+
+    /// Convert a time option to JSON
+    public func time(time : Time.Time) : Text {
+        quote(Int.toText(time))
+    };
+
+    /// Convert a tuple of (AdID, Ad) to JSON
+    public func ad((id : Ad.ID, ad : Ad.Ad)) : Text {
+        obj([
+            ("owner", text(ad.owner)),
+            ("id", quote(Nat.toText(id))),
+            ("image", image(ad.image)),
+            ("link", quote(ad.link)),
+            ("start", nullable(time, ad.start)),
+            ("end", nullable(time, ad.end)),
+            ("profile", nullable(target, ad.profile)),
+        ])
+    };
+
+    public func ads(iter : Iter.Iter<(Ad.ID, Ad.Ad)>) : Text {
+        array(Iter.map(iter, ad))
+    }
+}

--- a/src/ads_ledger/Target.mo
+++ b/src/ads_ledger/Target.mo
@@ -1,0 +1,62 @@
+/// Types and associated functions for ad target attributes
+module {
+    /// Standard age groups for targeting
+    public type Age = {
+        #age0_12;
+        #age13_17;
+        #age18_24;
+        #age25_34;
+        #age35_44;
+        #age45_54;
+        #age55_64;
+        #age65_74;
+        #age75_;
+    };
+
+    /// Primary gender expression to target
+    ///
+    /// This is obviously not an exhaustive list, but I have yet to see advertising catered to anything outside of these three categories. In most cases you shouldn't care about targeting gender anyway.
+    public type Gender = {
+        #masculine;
+        #non_binary;
+        #feminine;
+    };
+
+    /// Primary product/service of employee's organization (corresponding to sales, not job title)
+    public type Industry = Text;
+
+    /// Primary business function of an employee (corresponding to job title, not company)
+    public type Occupation = Text;
+
+    /// Topic user is interested in
+    ///
+    /// In addition to standard interests, this should be used instead of Dislike to represent things the user actively seeks to fight, e.g. Interest(anti-racism) instead of Dislike(racism).
+    public type Interest = Text;
+
+    /// Topic user is not interested in
+    ///
+    /// This is usually used client-side to hide topics from the user but could still be useful for targeting, e.g. Occupation(Software) AND Dislike(Amazon Web Services) for marketing alternative cloud platforms.
+    public type Dislike = Text;
+
+    /// Rules specifying what values of a type must exist to be considered a "match", using AND (`all`), OR (`some`), and NOT (`none`)
+    public type MatchRules<T> = {
+        /// All of these values must exist to be considered a match
+        all : [T];
+        /// At least one of these values must exist to be considered a match
+        some : [T];
+        /// None of these values can exist to be considered a match
+        none : [T];
+    };
+
+    // Profile attributes an ad is relevant to
+    ///
+    /// All attributes are optional, and non-null attributes are combined using AND, reducing the pool of candidate users to reach. For example, a Target with non-null `interests` and `dislikes` will match profiles matching the `interests` rules AND `dislikes` rules. For OR relationships, define multiple `Ad` objects.
+    public type Target = {
+        age : ?MatchRules<Age>;
+        gender : ?MatchRules<Gender>;
+        occupation : ?MatchRules<Occupation>;
+        industry : ?MatchRules<Industry>;
+        interests : ?MatchRules<Interest>;
+        dislikes : ?MatchRules<Dislike>;
+    };
+}

--- a/src/ads_ledger/main.mo
+++ b/src/ads_ledger/main.mo
@@ -1,7 +1,6 @@
 import Int "mo:base/Int";
 import Iter "mo:base/Iter";
 import Hash "mo:base/Hash";
-import Http "Http";
 import List "mo:base/List";
 import Nat "mo:base/Nat";
 import Nat16 "mo:base/Nat16";
@@ -9,240 +8,44 @@ import Text "mo:base/Text";
 import Time "mo:base/Time";
 import TrieMap "mo:base/TrieMap";
 
+import Ad "Ad";
+import Http "Http";
+import JSON "JSON";
+
 actor AdsLedger {
-    /**
-     * Types
-     */
-
-    public type AdID = Nat;
-
-    /// Standard age groups for targeting
-    ///
-    /// TODO: Find some alternative variant identifiers that start with a letter. Or yell at DFINITY to allow starting with an underscore.
-    public type Age = {
-        #age0_12;
-        #age13_17;
-        #age18_24;
-        #age25_34;
-        #age35_44;
-        #age45_54;
-        #age55_64;
-        #age65_74;
-        #age75_;
-    };
-
-    func ageToText(age : Age) : Text {
-        switch age {
-            case (#age0_12) "\"0-12\"";
-            case (#age13_17) "\"13-17\"";
-            case (#age18_24) "\"18-24\"";
-            case (#age25_34) "\"25-34\"";
-            case (#age35_44) "\"35-44\"";
-            case (#age45_54) "\"45-54\"";
-            case (#age55_64) "\"55-64\"";
-            case (#age65_74) "\"65-74\"";
-            case (#age75_) "\"75+\"";
-        }
-    };
-
-    /// Primary gender expression to target
-    ///
-    /// This is obviously not an exhaustive list, but I have yet to see advertising catered to anything outside of these three categories. In most cases you shouldn't care about targeting gender anyway.
-    public type Gender = {
-        #masculine;
-        #non_binary;
-        #feminine;
-    };
-
-    func genderToText(gender : Gender) : Text {
-        switch gender {
-            case (#masculine) "\"masculine\"";
-            case (#non_binary) "\"non_binary\"";
-            case (#feminine) "\"feminine\"";
-        }
-    };
-
-    /// Primary business function of an employee (corresponding to job title, not company)
-    public type Occupation = Text;
-
-    /// Primary product/service of employee's organization (corresponding to sales, not job title)
-    public type Industry = Text;
-
-    // TODO: Targeting province? region?
-    public type Country = Text;
-
-    /// Topic user is interested in
-    ///
-    /// In addition to standard interests, this should be used instead of Dislike to represent things the user actively seeks to fight, e.g. Interest(anti-racism) instead of Dislike(racism).
-    public type Interest = Text;
-
-    /// Topic user is not interested in
-    ///
-    /// This is usually used client-side to hide topics from the user but could still be useful for targeting, e.g. Occupation(Software) AND Dislike(Amazon Web Services) for marketing alternative cloud platforms.
-    public type Dislike = Text;
-
-    /// Rules specifying what values of a type must exist to be considered a "match", using AND (`all`), OR (`some`), and NOT (`none`)
-    public type MatchRules<T> = {
-        /// All of these values must exist to be considered a match
-        all : [T];
-        /// At least one of these values must exist to be considered a match
-        some : [T];
-        /// None of these values can exist to be considered a match
-        none : [T];
-    };
-
-    /// Serialize a `MatchRules<Text>` to JSON
-    ///
-    /// TODO: Generic serialization?
-    func textRulesToJson(rules : ?MatchRules<Text>) : Text {
-        switch rules {
-            case null
-                "null";
-            case (?rules)
-                "{" #
-                    "\"all\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.all), func (text : Text) : Text {"\"" # text # "\""})) # "]," #
-                    "\"some\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.some), func (text : Text) : Text {"\"" # text # "\""})) # "]," #
-                    "\"none\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.none), func (text : Text) : Text {"\"" # text # "\""})) # "]" #
-                "}";
-        }
-    };
-
-    /// Serialize a `MatchRules<Gender>` to JSON
-    func genderRulesToJson(rules : ?MatchRules<Gender>) : Text {
-        switch rules {
-            case null
-                "null";
-            case (?rules)
-                "{" #
-                    "\"all\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.all), genderToText)) # "]," #
-                    "\"some\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.some), genderToText)) # "]," #
-                    "\"none\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.none), genderToText)) # "]" #
-                "}";
-        }
-    };
-
-    /// Serialize a `MatchRules<Age>` to JSON
-    func ageRulesToJson(rules : ?MatchRules<Age>) : Text {
-        switch rules {
-            case null
-                "null";
-            case (?rules)
-                "{" #
-                    "\"all\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.all), ageToText)) # "]," #
-                    "\"some\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.some), ageToText)) # "]," #
-                    "\"none\":[" # Text.join(",", Iter.map(Iter.fromArray(rules.none), ageToText)) # "]" #
-                "}";
-        }
-    };
-
-    /// Profile attributes an ad is relevant to
-    ///
-    /// All attributes are optional, and non-null attributes are combined using AND, reducing the pool of candidate users to reach. For example, a Target with non-null `interests` and `dislikes` will match profiles matching the `interests` rules AND `dislikes` rules. For OR relationships, define multiple `Ad` objects.
-    public type Target = {
-        age : ?MatchRules<Age>;
-        gender : ?MatchRules<Gender>;
-        occupation : ?MatchRules<Occupation>;
-        industry : ?MatchRules<Industry>;
-        interests : ?MatchRules<Interest>;
-        dislikes : ?MatchRules<Dislike>;
-    };
-
-    func targetToJson(target : Target) : Text {
-        "{" #
-            "\"age\":" # ageRulesToJson(target.age) # "," #
-            "\"gender\":" # genderRulesToJson(target.gender) # "," #
-            "\"occupation\":" # textRulesToJson(target.occupation) # "," #
-            "\"industry\":" # textRulesToJson(target.industry) # "," #
-            "\"interests\":" # textRulesToJson(target.interests) # "," #
-            "\"dislikes\":" # textRulesToJson(target.dislikes) #
-        "}"
-    };
-
-    public type Image = {
-        url : Text;
-        height : Nat16;
-        width : Nat16;
-    };
-
-    func imageToJson(image : Image) : Text {
-        "{" #
-            "\"url\":\"" # image.url # "\"," #
-            "\"height\":" # Nat16.toText(image.height) # "," #
-            "\"width\":" # Nat16.toText(image.width) #
-        "}"
-    };
-
-    /// Ad campaign containing `image` and `link` to be shown to users matching `profile` between `start` and `end`
-    public type Ad = {
-        /// User with control over this ad
-        owner : Text;
-        /// Link to ad content
-        /// TODO: Host blob on-chain, once Candid UI supports blob uploads
-        image : Image;
-        /// URL the user should visit after clicking on the ad
-        link : Text;
-        /// Profile attributes this ad is relevant to, or null for no targeting
-        profile : ?Target;
-        /// Time this campaign starts
-        start : ?Time.Time;
-        /// Time this campaign ends
-        end : ?Time.Time;
-    };
-
-    func adToJson((id : AdID, ad : Ad)) : Text {
-        "{" #
-            "\"owner\":\"" # ad.owner # "\"," #
-            "\"id\":\"" # Nat.toText(id) # "\"," #
-            "\"image\":" # imageToJson(ad.image) # "," #
-            "\"link\":\"" # ad.link # "\"," #
-            "\"start\":" # (switch (ad.start) {
-                case null "null";
-                case (?start) "\"" # Int.toText(start) # "\"";
-            }) # "," #
-            "\"end\":" # (switch (ad.end) {
-                case null "null";
-                case (?end) "\"" # Int.toText(end) # "\"";
-            }) # "," #
-            "\"profile\":" # (switch (ad.profile) {
-                case null "null";
-                case (?profile) targetToJson(profile);
-            }) #
-        "}"
-    };
-
     /**
      * Private implementation details
      */
     
-    /// Returns if two AdIDs are equal
-    func equalID(a : AdID, b: AdID) : Bool {
+    /// Returns true if two AdIDs are equal
+    func equalID(a : Ad.ID, b: Ad.ID) : Bool {
         a == b
     };
 
     /// Hash function used in ads map
     /// XXX: Apparently getting moved someday?
-    let hashID : AdID -> Hash.Hash = Int.hash;
+    let hashID : Ad.ID -> Hash.Hash = Int.hash;
 
     /**
      * Application State
-     * 
-     * HashMap isn't stable so none of this is stable at the moment
      */
 
     /// Next available `Ad` id
     ///
     /// TODO: Could this be subject to race conditions? Docs unclear on when race conditions are possible
-    stable var nextID : AdID = 0;
+    stable var nextID : Ad.ID = 0;
 
     /// Ad repository backup used during canister code upgrades
-    stable var adsBackup : [(AdID, Ad)] = [];
+    stable var adsBackup : [(Ad.ID, Ad.Ad)] = [];
     /// Ad repository used during runtime
     var ads = TrieMap.fromEntries(adsBackup.vals(), equalID, hashID);
 
+    /// Store ads map to stable array before canister upgrade
     system func preupgrade() {
         adsBackup := Iter.toArray(ads.entries());
     };
 
+    /// Clear stable array backup after canister upgrade
     system func postupgrade() {
         adsBackup := [];
     };
@@ -250,21 +53,15 @@ actor AdsLedger {
     /**
      * "API" I guess
      */
- 
-    func allAdsJsonPrivate() : Text {
-        "[" #
-            Text.join(",", Iter.map(ads.entries(), adToJson)) #
-        "]"
-    };
 
     public query func allAdsJson() : async Text {
-        allAdsJsonPrivate()
+        JSON.ads(ads.entries())
     };
     
     /// Add an ad to the ledger
     ///
     /// @return ID of the added ad
-    public func add(ad : Ad) : async AdID {
+    public func add(ad : Ad.Ad) : async Ad.ID {
         let id = nextID;
         nextID += 1;
         ads.put(id, ad);
@@ -274,14 +71,14 @@ actor AdsLedger {
     /// Delete an ad from the ledger
     ///
     /// @return The Ad that was just deleted, or null if it didn't exist
-    public func delete(id : AdID) : async ?Ad {
+    public func delete(id : Ad.ID) : async ?Ad.Ad {
         return ads.remove(id);
     };
 
     /// Get an ad from the ledger
     ///
     /// @return The Ad with the corresponding ID, or null if it doesn't exist
-    public func get(id : AdID) : async ?Ad {
+    public func get(id : Ad.ID) : async ?Ad.Ad {
         return ads.get(id);
     };
 
@@ -289,7 +86,7 @@ actor AdsLedger {
     ///
     /// If an ad
     /// @return Previous Ad existing at that ID, or null if that ID isn't in use
-    public func replace(id : AdID, newAd : Ad) : async ?Ad {
+    public func replace(id : Ad.ID, newAd : Ad.Ad) : async ?Ad.Ad {
         // Make sure ID is in use to avoid inserting ads at Ids the ID generator doesn't know about
         return switch (ads.get(id)) {
             case (?oldAd) ads.replace(id, newAd);
@@ -297,11 +94,14 @@ actor AdsLedger {
         }
     };
 
-    /// Return a map of all ads in the ledger
-    public query func getAds() : async List.List<(AdID, Ad)> {
+    /// Return a list of all ads in the ledger
+    ///
+    /// @return List of (Ad.ID, Ad.Ad) tuples
+    public query func getAds() : async List.List<(Ad.ID, Ad.Ad)> {
         Iter.toList(ads.entries())
     };
 
+    /// Return JSON of all the ads in the ledger, or reject if not GET /
     public query func http_request(request : Http.Request) : async Http.Response {
         // Reject non-root paths
         if (request.url != "/") {
@@ -315,7 +115,7 @@ actor AdsLedger {
 
         // Reject non-GET/HEAD requests
         // Case sensitive matching because the HTTP protocol is case-sensitive
-        // Also Motko doesn't have capitalization functions in the standard library
+        // Also Motoko doesn't have capitalization functions in the standard library
         // TODO: Support HEAD?
         if (request.method != "GET") {
             let body = Http.textToNat8s("Method Not Allowed");
@@ -329,7 +129,7 @@ actor AdsLedger {
             }
         };
 
-        let body = Http.textToNat8s(allAdsJsonPrivate());
+        let body = Http.textToNat8s(JSON.ads(ads.entries()));
         return {
             status_code = 200;
             headers = [


### PR DESCRIPTION
Splitting out Ad and Target made the code a lot more readable.

However, the new JSON module is incredibly awesome. Instead of writing independent serialization functions for each type, I aimed to create a "library" of sorts that allows you to compose JSON objects. It's so much more readable and so much more compact. I love it.